### PR TITLE
Choose which language to translate to

### DIFF
--- a/i17obot/config.py
+++ b/i17obot/config.py
@@ -1,0 +1,15 @@
+import os
+
+import decouple
+
+
+BASE_DIR = os.path.dirname(__file__)
+
+DATABASE = decouple.config("DATABASE")
+
+ADMINS = decouple.config("ADMINS", cast=decouple.Csv(int))
+
+AVAILABLE_LANGUAGES = {
+    "pt_br": "Brazilian Portuguese",
+    "es": "Spanish",
+}

--- a/i17obot/database.py
+++ b/i17obot/database.py
@@ -1,7 +1,8 @@
 import motor.motor_asyncio
-from decouple import config
 
-client = motor.motor_asyncio.AsyncIOMotorClient(config("DATABASE"))
+import config
+
+client = motor.motor_asyncio.AsyncIOMotorClient(config.DATABASE)
 db = client.i17obot
 
 
@@ -18,10 +19,14 @@ async def create_user(telegram_user, chat_type):
         )
 
 
-async def toggle_reminder(id):
-    user = await db.users.find_one({"id": id})
+async def update_user(user_id, **kwargs):
+    await db.users.update_one({"id": user_id}, {"$set": kwargs})
+
+
+async def toggle_reminder(user_id):
+    user = await db.users.find_one({"id": user_id})
     reminder = user.get("reminder_set", False)
-    await db.users.update_one({"id": id}, {"$set": {"reminder_set": not reminder}})
+    await db.users.update_one({"id": user_id}, {"$set": {"reminder_set": not reminder}})
     return not reminder
 
 

--- a/i17obot/main.py
+++ b/i17obot/main.py
@@ -9,6 +9,7 @@ from aiogram.utils import exceptions, executor
 from aiogram.dispatcher.middlewares import BaseMiddleware
 from decouple import config
 
+import config
 import handlers
 import messages
 from telegram import bot
@@ -33,6 +34,12 @@ if __name__ == "__main__":
     dp.middleware.setup(CreateUserMiddleware())
 
     dp.register_message_handler(handlers.start, commands=["start", "help", "ajuda"])
+
+    dp.register_message_handler(handlers.language, commands=["language"])
+    dp.register_callback_query_handler(
+        handlers.set_language, lambda query: query.data in config.AVAILABLE_LANGUAGES,
+    )
+
     dp.register_message_handler(
         handlers.translate_at_transifex, commands=["translate", "traduzir"]
     )


### PR DESCRIPTION
This PR is the first step to allow multiple languages in the bot. It adds the `/language` command that asks the user to choose which language to translate the documentation.